### PR TITLE
Fix bug with extended DateTime, improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 1.0.0 August 26, 2020
 
-- Initial release.
+- Bug #41: Fix bug with instances of extended `DateTime` class (@Tigrov)
+- Enh #41: Improve performance for `DateTimeInterface` and `SimpleXMLElement` instences (@Tigrov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## 1.0.0 August 26, 2020
 
 - Bug #41: Fix bug with instances of extended `DateTime` class (@Tigrov)
-- Enh #41: Improve performance for `DateTimeInterface` and `SimpleXMLElement` instences (@Tigrov)
+- Enh #41: Improve performance (@Tigrov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Yii JSON Change Log
 
-## 1.0.0 August 26, 2020
+## 1.0.1 under development
 
 - Bug #41: Fix bug with instances of extended `DateTime` class (@Tigrov)
 - Enh #41: Improve performance (@Tigrov)
+
+## 1.0.0 August 26, 2020
+
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.1 under development
 
 - Bug #41: Fix bug with instances of extended `DateTime` class (@Tigrov)
-- Enh #41: Improve performance (@Tigrov)
+- Enh #41: Improve performance of `Json::encode()` method by 10-20% (@Tigrov)
 
 ## 1.0.0 August 26, 2020
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -11,6 +11,7 @@ use SimpleXMLElement;
 use stdClass;
 use Traversable;
 
+use function get_object_vars;
 use function json_decode;
 use function json_encode;
 use function is_array;
@@ -161,6 +162,6 @@ final class Json
             return self::processArray(iterator_to_array($data)) ?: new stdClass();
         }
 
-        return self::processArray((array)$data) ?: new stdClass();
+        return self::processArray(get_object_vars($data)) ?: new stdClass();
     }
 }

--- a/tests/DateTimeExtended.php
+++ b/tests/DateTimeExtended.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Json\Tests;
+
+use DateTime;
+
+final class DateTimeExtended extends DateTime
+{
+    private string $private = 'private property';
+
+    public string $public = 'public property';
+}

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -13,6 +13,10 @@ use SplStack;
 use stdClass;
 use Yiisoft\Json\Json;
 
+use function fclose;
+use function fopen;
+use function json_encode;
+
 final class JsonTest extends TestCase
 {
     public function testEncodeBasic(): void
@@ -143,6 +147,12 @@ final class JsonTest extends TestCase
         $this->assertSame('[["42"]]', Json::encode($data));
     }
 
+    public function testEncodeEmptySimpleXmlElement(): void
+    {
+        $data = new SimpleXMLElement('<value/>');
+        $this->assertSame('{}', Json::encode($data));
+    }
+
     public function testsHtmlEncodeSplStack(): void
     {
         $postsStack = new SplStack();
@@ -207,5 +217,16 @@ final class JsonTest extends TestCase
     {
         $input = new DateTime('October 12, 2014', new DateTimeZone('UTC'));
         $this->assertEquals('{"date":"2014-10-12 00:00:00.000000","timezone_type":3,"timezone":"UTC"}', Json::encode($input));
+    }
+
+    public function testEncodeDateTimeExtended()
+    {
+        $input = new DateTimeExtended('2023-09-09 10:00:00');
+
+        $this->assertEquals(
+            '{"public":"public property","date":"2023-09-09 10:00:00.000000","timezone_type":3,"timezone":"UTC"}',
+            Json::encode($input),
+        );
+        $this->assertSame(json_encode($input), Json::encode($input));
     }
 }

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -82,6 +82,12 @@ final class JsonTest extends TestCase
         $this->assertSame('{}', Json::encode($data));
     }
 
+    public function testEncodeWithSerializableReturningScalar(): void
+    {
+        $data = new Data('string');
+        $this->assertSame('"string"', Json::encode($data));
+    }
+
     public function testsHtmlEncodeEscapesCharacters(): void
     {
         $this->assertSame('"\u0026\u003C\u003E\u0022\u0027\/"', Json::htmlEncode('&<>"\'/'));

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -237,4 +237,9 @@ final class JsonTest extends TestCase
         );
         $this->assertSame(json_encode($input), Json::encode($input));
     }
+
+    public function testEncodeObjectProperties()
+    {
+        $this->assertSame('{"public":"public"}', Json::encode(new Properties()));
+    }
 }

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -33,6 +33,7 @@ final class JsonTest extends TestCase
     {
         $this->assertSame('[1,2]', Json::encode([1, 2]));
         $this->assertSame('{"a":1,"b":2}', Json::encode(['a' => 1, 'b' => 2]));
+        $this->assertSame('{"a":[null],"b":{"c":"d"}}', Json::encode(['a' => [null], 'b' => ['c' => 'd']]));
     }
 
     public function testEncodeSimpleObject(): void
@@ -40,7 +41,8 @@ final class JsonTest extends TestCase
         $data = new stdClass();
         $data->a = 1;
         $data->b = 2;
-        $this->assertSame('{"a":1,"b":2}', Json::encode($data));
+        $data->c = ['d' => ['e' => 3]];
+        $this->assertSame('{"a":1,"b":2,"c":{"d":{"e":3}}}', Json::encode($data));
     }
 
     public function testEncodeEmpty(): void

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -223,7 +223,7 @@ final class JsonTest extends TestCase
     {
         $input = new DateTimeExtended('2023-09-09 10:00:00');
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"public":"public property","date":"2023-09-09 10:00:00.000000","timezone_type":3,"timezone":"UTC"}',
             Json::encode($input),
         );

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -240,6 +240,8 @@ final class JsonTest extends TestCase
 
     public function testEncodeObjectProperties()
     {
-        $this->assertSame('{"public":"public"}', Json::encode(new Properties()));
+        $object = new Properties();
+        $this->assertSame('{"public":"public"}', Json::encode($object));
+        $this->assertSame(json_encode($object), Json::encode($object));
     }
 }

--- a/tests/Properties.php
+++ b/tests/Properties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Json\Tests;
+
+class Properties
+{
+    private string $private = 'private';
+
+    protected string $protected = 'protected';
+
+    public string $public = 'public';
+}


### PR DESCRIPTION
* Fix bug with extended `DateTime`
* Improve performance of `Json::encode()` by 10-20%

![2023-09-09_23-59-38](https://github.com/yiisoft/json/assets/8563175/ade700d4-ea19-404e-987b-f7859b26a7e8)

## About [`jsonSerialize()`](https://github.com/yiisoft/json/pull/41/files#diff-4d6abb4819907e506412afc1e1abc34ffbd6331a7eb45b143da576950fd7ae7aR140)

The [PHP documentation](https://www.php.net/manual/en/jsonserializable.jsonserialize.php) mentions: *Returns data which can be serialized by `json_encode()`*

The [`processObject()`](https://github.com/yiisoft/json/pull/41/files#diff-4d6abb4819907e506412afc1e1abc34ffbd6331a7eb45b143da576950fd7ae7aR136) should return the result of `jsonSerialize()` without processing:

```php
return $data->jsonSerialize();
```

But this breaks BC.

If it is requered to pre-process data for `jsonSerialize()`, this should be done inside `jsonSerialize()`:

```php
...
public function jsonSerialize(): mixed
{
    return Json:process($this->data);
}
...
```

What do you think? Do this for the next major version?

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -